### PR TITLE
 Change default site language

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -3,7 +3,7 @@ languageCode = 'en-us'
 title = 'ScalHive'
 theme = ["github.com/TNTU-RS-internship/scalhive-theme"]
 
-DefaultContentLanguage = "en"
+DefaultContentLanguage = "ua"
 [languages]
  [languages.en]
   languageCode = 'en'


### PR DESCRIPTION
Closes #91 
In config/_default/hugo.toml changed the initial language of the site from 'en' to 'ua'.